### PR TITLE
Implement numpy voodoo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+source/aerobulk/_version.py export-subst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include versioneer.py
+include source/aerobulk/_version.py

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,16 @@
 import os
 
+# We need to import setuptools here in order for it to persist in sys.modules.
+# Its presence/absence is used in subclassing setup in numpy/distutils/core.py.
+# However, we need to run the distutils version of sdist, so import that first
+# so that it is in sys.modules
+import numpy.distutils.command.sdist  # noqa
+import setuptools  # noqa
 from numpy.distutils.core import Extension, setup
 from numpy.distutils.fcompiler import get_default_fcompiler
+
+# Trying this from the numpy setup.py
+
 
 here = os.path.dirname(__file__)
 with open(os.path.join(here, "README.md"), encoding="utf-8") as f:


### PR DESCRIPTION
So we had trouble with getting the correct version for the source distribution [here](https://github.com/xgcm/aerobulk-python/actions/runs/2430653261). 

I ran some tests and somehow seem to have fixed this by addind some lines from the numpy setup.py. 

I DO NOT understand at all what is going on, but well lets try...