### PR TITLE
Change standard heights in docstring

### DIFF
--- a/source/aerobulk/flux.py
+++ b/source/aerobulk/flux.py
@@ -223,10 +223,10 @@ def noskin(
         by default "coare3p0"
     zt : int, optional
         height for temperature and spec. hum. of air           [m],
-        by default 10
+        by default 2
     zu : int, optional
         height for wind (10m = traditional anemometric height  [m],
-        by default 2
+        by default 10
     niter : int, optional
         Number of iteration steps used in the algorithm,
         by default 6
@@ -327,10 +327,10 @@ def skin(
         by default "coare3p0"
     zt : int, optional
         height for temperature and spec. hum. of air           [m],
-        by default 10
+        by default 2
     zu : int, optional
         height for wind (10m = traditional anemometric height  [m],
-        by default 2
+        by default 10
     niter : int, optional
         Number of iteration steps used in the algorithm,
         by default 6


### PR DESCRIPTION
I accidentally pushed changes to the standard heights to the main branch. This is updating the docstrings. 

@paigem do you have information on the CESM data that you could compare to these values? They are currently adjusted to CM2.6