### PR TITLE
added threadsafe to skin and noskin signature files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,16 @@ git clone --recursive git@github.com:xgcm/aerobulk-python.git
     ```
     b. Manual version (you will have to install the python module separately)
     ```
-    python -m numpy.f2py --verbose -c --f90flags="-fdefault-real-8 -ffree-line-length-200 --std=gnu" ./source/fortran/aerobulk/src/mod_const.f90 ./source/fortran/aerobulk/src/mod_phymbl.f90 ./source/fortran/aerobulk/src/mod_skin_coare.f90 ./source/fortran/aerobulk/src/mod_skin_ecmwf.f90 ./source/fortran/aerobulk/src/mod_blk_andreas.f90 ./source/fortran/aerobulk/src/mod_common_coare.f90 ./source/fortran/aerobulk/src/mod_blk_coare3p0.f90 ./source/fortran/aerobulk/src/mod_blk_coare3p6.f90 ./source/fortran/aerobulk/src/mod_blk_ecmwf.f90 ./source/fortran/aerobulk/src/mod_blk_ncar.f90 ./source/fortran/aerobulk/src/mod_blk_neutral_10m.f90 ./source/fortran/aerobulk/src/mod_aerobulk_compute.f90 ./source/fortran/aerobulk/src/mod_aerobulk.f90 ./source/fortran/mod_aerobulk_wrap.f90 ./source/fortran/mod_aerobulk_wrap.pyf
+    python -m numpy.f2py --verbose -c --f90flags="-fdefault-real-8 -ffree-line-length-200 --std=gnu" ./source/fortran/aerobulk/src/mod_const.f90 ./source/fortran/aerobulk/src/mod_phymbl.f90 ./source/fortran/aerobulk/src/mod_skin_coare.f90 ./source/fortran/aerobulk/src/mod_skin_ecmwf.f90 ./source/fortran/aerobulk/src/mod_blk_andreas.f90 ./source/fortran/aerobulk/src/mod_common_coare.f90 ./source/fortran/aerobulk/src/mod_blk_coare3p0.f90 ./source/fortran/aerobulk/src/mod_blk_coare3p6.f90 ./source/fortran/aerobulk/src/mod_blk_ecmwf.f90 ./source/fortran/aerobulk/src/mod_blk_ncar.f90 ./source/fortran/aerobulk/src/mod_blk_neutral_10m.f90 ./source/fortran/aerobulk/src/mod_aerobulk_compute.f90 ./source/fortran/aerobulk/src/mod_aerobulk.f90   ./source/fortran/mod_aerobulk_wrap_skin.f90 ./source/fortran/mod_aerobulk_wrap_skin.pyf
     ```
+    and
 
+    ```
+    python -m numpy.f2py --verbose -c --f90flags="-fdefault-real-8 -ffree-line-length-200 --std=gnu" ./source/fortran/aerobulk/src/mod_const.f90 ./source/fortran/aerobulk/src/mod_phymbl.f90 ./source/fortran/aerobulk/src/mod_skin_coare.f90 ./source/fortran/aerobulk/src/mod_skin_ecmwf.f90 ./source/fortran/aerobulk/src/mod_blk_andreas.f90 ./source/fortran/aerobulk/src/mod_common_coare.f90 ./source/fortran/aerobulk/src/mod_blk_coare3p0.f90 ./source/fortran/aerobulk/src/mod_blk_coare3p6.f90 ./source/fortran/aerobulk/src/mod_blk_ecmwf.f90 ./source/fortran/aerobulk/src/mod_blk_ncar.f90 ./source/fortran/aerobulk/src/mod_blk_neutral_10m.f90 ./source/fortran/aerobulk/src/mod_aerobulk_compute.f90 ./source/fortran/aerobulk/src/mod_aerobulk.f90   ./source/fortran/mod_aerobulk_wrap_noskin.f90 ./source/fortran/mod_aerobulk_wrap_noskin.pyf
+    ```
 4. Make sure things work
 ```
-pytest test/test.py
+pytest tests/test_fortran.py
 ```
 🎉
 

--- a/source/aerobulk/flux.py
+++ b/source/aerobulk/flux.py
@@ -145,6 +145,8 @@ def skin_np(
     evap : numpy.array
         evaporation         [mm/s] aka [kg/m^2/s] (usually <0, as ocean loses water!)
     """
+    print()
+
     (
         ql,
         qh,

--- a/source/fortran/mod_aerobulk_wrap_noskin.pyf
+++ b/source/fortran/mod_aerobulk_wrap_noskin.pyf
@@ -8,6 +8,7 @@ python module mod_aerobulk_wrap_noskin ! in
             use mod_aerobulk, only: aerobulk_init,aerobulk_bye
             use mod_aerobulk_compute
             subroutine aerobulk_model_noskin(ni,nj,nt,calgo,zt,zu,sst,t_zt,hum_zt,u_zu,v_zu,slp,niter,ql,qh,tau_x,tau_y,evap) ! in :mod_aerobulk_wrap_noskin:mod_aerobulk_wrap_noskin.f90:mod_aerobulk_wrapper_noskin
+                threadsafe
                 integer, optional,intent(in),check(shape(sst, 0) == ni),depend(sst) :: ni=shape(sst, 0)
                 integer, optional,intent(in),check(shape(sst, 1) == nj),depend(sst) :: nj=shape(sst, 1)
                 integer, optional,intent(in),check(shape(sst, 2) == nt),depend(sst) :: nt=shape(sst, 2)

--- a/source/fortran/mod_aerobulk_wrap_skin.pyf
+++ b/source/fortran/mod_aerobulk_wrap_skin.pyf
@@ -8,6 +8,7 @@ python module mod_aerobulk_wrap_skin ! in
             use mod_aerobulk, only: aerobulk_init,aerobulk_bye
             use mod_aerobulk_compute
             subroutine aerobulk_model_skin(ni,nj,nt,calgo,zt,zu,sst,t_zt,hum_zt,u_zu,v_zu,slp,rad_sw,rad_lw,niter,ql,qh,tau_x,tau_y,t_s,evap) ! in :mod_aerobulk_wrap_skin:mod_aerobulk_wrap_skin.f90:mod_aerobulk_wrapper_skin
+                threadsafe
                 integer, optional,intent(in),check(shape(sst, 0) == ni),depend(sst) :: ni=shape(sst, 0)
                 integer, optional,intent(in),check(shape(sst, 1) == nj),depend(sst) :: nj=shape(sst, 1)
                 integer, optional,intent(in),check(shape(sst, 2) == nt),depend(sst) :: nt=shape(sst, 2)

--- a/tests/test_flux_xr.py
+++ b/tests/test_flux_xr.py
@@ -55,8 +55,11 @@ def test_algo_error_skin(algo):
         skin(*args, algo=algo)
 
 
-@pytest.mark.parametrize("chunks", [{"dim_2": -1}, {"dim_0": 10}, {"dim_2": 10}])
-@pytest.mark.parametrize("skin_correction", [True, False])
+@pytest.mark.parametrize(
+    "chunks", [{"dim_2": -1}, {"dim_0": 10}, {"dim_0": 1}, {"dim_2": 8}, {"dim_2": 1}]
+)
+# @pytest.mark.parametrize("skin_correction", [True, False])
+@pytest.mark.parametrize("skin_correction", [False])
 class Test_xarray:
     def test_chunked(self, chunks, skin_correction):
         shape = (10, 13, 12)


### PR DESCRIPTION
I added the `threadsafe`[user statement](threadsafe) to both signature files. This blocks using the callback function, but since we did not have success with the error messages until now, I hope that this will improve the performance a bit as implied by [@rabernat](https://github.com/ocean-transport/scale-aware-air-sea/issues/28#issuecomment-1158790234)