### PR TITLE
Handle land mask

### DIFF
--- a/source/aerobulk/flux.py
+++ b/source/aerobulk/flux.py
@@ -33,7 +33,7 @@ def noskin_np(
 ):
     """Python wrapper for aerobulk without skin correction.
     !ATTENTION If input not provided in correct units, will crash.
-    !ATTENTION Land mask taken from NaN values in sst field. No input variables may have NaN values that are not reflected in the sst.
+    !ATTENTION Missing values taken from NaN values in sst field. No input variables may have NaN values that are not reflected in the sst.
 
     Parameters
     ----------
@@ -108,7 +108,7 @@ def skin_np(
 ):
     """Python wrapper for aerobulk with skin correction.
     !ATTENTION If input not provided in correct units, will crash.
-    !ATTENTION Land mask taken from NaN values in sst field. No input variables may have NaN values that are not reflected in the sst.
+    !ATTENTION Missing values taken from NaN values in sst field. No input variables may have NaN values that are not reflected in the sst.
 
     Parameters
     ----------
@@ -181,7 +181,7 @@ def noskin(
     Warnings
     --------
     !ATTENTION If input not provided in the units shown in [] below the code will crash.
-    !ATTENTION Land mask taken from NaN values in sst field. No input variables may have NaN values that are not reflected in the sst.
+    !ATTENTION Missing values taken from NaN values in sst field. No input variables may have NaN values that are not reflected in the sst.
 
     Parameters
     ----------
@@ -281,7 +281,7 @@ def skin(
     Warnings
     --------
     !ATTENTION If input not provided in the units shown in [] below the code will crash.
-    !ATTENTION Land mask taken from NaN values in sst field. No input variables may have NaN values that are not reflected in the sst.
+    !ATTENTION Missing values taken from NaN values in sst field. No input variables may have NaN values that are not reflected in the sst.
 
     Parameters
     ----------

--- a/source/aerobulk/flux.py
+++ b/source/aerobulk/flux.py
@@ -35,6 +35,7 @@ def noskin_np(
 ):
     """Python wrapper for aerobulk without skin correction.
     !ATTENTION If input not provided in correct units, will crash.
+    !ATTENTION Land mask taken from NaN values in sst field. No input variables may have NaN values that are not reflected in the sst.
 
     Parameters
     ----------
@@ -109,6 +110,7 @@ def skin_np(
 ):
     """Python wrapper for aerobulk with skin correction.
     !ATTENTION If input not provided in correct units, will crash.
+    !ATTENTION Land mask taken from NaN values in sst field. No input variables may have NaN values that are not reflected in the sst.
 
     Parameters
     ----------
@@ -213,6 +215,7 @@ def noskin(
     Warnings
     --------
     !ATTENTION If input not provided in the units shown in [] below the code will crash.
+    !ATTENTION Land mask taken from NaN values in sst field. No input variables may have NaN values that are not reflected in the sst.
 
     Parameters
     ----------
@@ -313,6 +316,7 @@ def skin(
     Warnings
     --------
     !ATTENTION If input not provided in the units shown in [] below the code will crash.
+    !ATTENTION Land mask taken from NaN values in sst field. No input variables may have NaN values that are not reflected in the sst.
 
     Parameters
     ----------

--- a/source/aerobulk/flux.py
+++ b/source/aerobulk/flux.py
@@ -1,5 +1,3 @@
-import functools
-
 import aerobulk.aerobulk.mod_aerobulk_wrap_noskin as aeronoskin
 import aerobulk.aerobulk.mod_aerobulk_wrap_skin as aeroskin
 import numpy as np
@@ -175,38 +173,6 @@ def skin_np(
     return tuple(unshrink_arr(o, sst.shape, ocean_index) for o in out_data)
 
 
-def input_and_output_check(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        # Check the input shape
-        test_arg = args[
-            0
-        ]  # assuming that all the input shapes are the same size. TODO: More thorough check
-        if len(test_arg.dims) < 3:
-            # TODO promote using expand_dims?
-            raise NotImplementedError(
-                f"Aerobulk-Python expects all input fields as 3D arrays. Found {len(test_arg.dims)} dimensions on input."
-            )
-        if len(test_arg.dims) > 4:
-            # TODO iterate over extra dims? Or reshape?
-            raise NotImplementedError(
-                f"Aerobulk-Python expects all input fields as 3D arrays. Found {len(test_arg.dims)} dimensions on input."
-            )
-
-        out_vars = func(*args, **kwargs)
-
-        # TODO: Here we could 'un-reshape' or squeeze the output according to the logic above
-
-        if any(var.ndim != 3 for var in out_vars):
-            raise ValueError(
-                f"f2py returned result of unexpected shape. Got {[var.shape for var in out_vars]}"
-            )
-        return out_vars
-
-    return wrapper
-
-
-@input_and_output_check
 def noskin(
     sst, t_zt, hum_zt, u_zu, v_zu, slp=101000.0, algo="coare3p0", zt=2, zu=10, niter=6
 ):
@@ -295,7 +261,6 @@ def noskin(
     return out_vars
 
 
-@input_and_output_check
 def skin(
     sst,
     t_zt,

--- a/source/fortran/mod_aerobulk_wrap_skin.pyf
+++ b/source/fortran/mod_aerobulk_wrap_skin.pyf
@@ -8,7 +8,7 @@ python module mod_aerobulk_wrap_skin ! in
             use mod_aerobulk, only: aerobulk_init,aerobulk_bye
             use mod_aerobulk_compute
             subroutine aerobulk_model_skin(ni,nj,nt,calgo,zt,zu,sst,t_zt,hum_zt,u_zu,v_zu,slp,rad_sw,rad_lw,niter,ql,qh,tau_x,tau_y,t_s,evap) ! in :mod_aerobulk_wrap_skin:mod_aerobulk_wrap_skin.f90:mod_aerobulk_wrapper_skin
-                threadsafe
+
                 integer, optional,intent(in),check(shape(sst, 0) == ni),depend(sst) :: ni=shape(sst, 0)
                 integer, optional,intent(in),check(shape(sst, 1) == nj),depend(sst) :: nj=shape(sst, 1)
                 integer, optional,intent(in),check(shape(sst, 2) == nt),depend(sst) :: nt=shape(sst, 2)

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -21,14 +21,14 @@ def create_data(
 
     def _arr(value, chunks, order):
         arr = np.full(shape, value, order=order)
-        if use_xr:
-            arr = xr.DataArray(arr)
         if land_mask:
             arr[
                 multi_indices[0], multi_indices[1], :
             ] = np.nan  # add NaNs to mimic land mask
-        if chunks:
-            arr = arr.chunk(chunks)
+        if use_xr:
+            arr = xr.DataArray(arr)
+            if chunks:
+                arr = arr.chunk(chunks)
 
         # adds random noise scaled by a percentage of the value
         randomize_factor = 0.001

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -26,7 +26,7 @@ def create_data(
         randomize_range = value * randomize_factor
         noise = np.random.rand(*shape) * randomize_range
         arr = arr + noise
-        
+
         if land_mask:
             arr[
                 multi_indices[0], multi_indices[1], :

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -21,6 +21,12 @@ def create_data(
 
     def _arr(value, chunks, order):
         arr = np.full(shape, value, order=order)
+        # adds random noise scaled by a percentage of the value
+        randomize_factor = 0.001
+        randomize_range = value * randomize_factor
+        noise = np.random.rand(*shape) * randomize_range
+        arr = arr + noise
+        
         if land_mask:
             arr[
                 multi_indices[0], multi_indices[1], :
@@ -29,12 +35,6 @@ def create_data(
             arr = xr.DataArray(arr)
             if chunks:
                 arr = arr.chunk(chunks)
-
-        # adds random noise scaled by a percentage of the value
-        randomize_factor = 0.001
-        randomize_range = value * randomize_factor
-        noise = np.random.rand(*shape) * randomize_range
-        arr = arr + noise
         return arr
 
     sst = _arr(290.0, chunks, order)

--- a/tests/test_flux_np.py
+++ b/tests/test_flux_np.py
@@ -1,50 +1,9 @@
-from typing import Dict, Tuple
-
 import numpy as np
 import pytest
 from aerobulk.flux import noskin_np, skin_np
-from numpy.random import default_rng
+from create_test_data import create_data
 
-
-def create_data_np(
-    shape: Tuple[int, ...],
-    chunks: Dict[str, int] = {},
-    skin_correction: bool = False,
-    order: str = "F",
-):
-    size = shape[0] * shape[1]
-    shape2d = (shape[0], shape[1])
-    rng = default_rng()
-    indices = rng.choice(size, size=int(size * 0.3), replace=False)
-    multi_indices = np.unravel_index(indices, shape2d)
-
-    def _arr(value, chunks, order, land_mask=False):
-        raw_data = np.full(shape, value, order=order)
-        if land_mask:
-            raw_data[
-                multi_indices[0], multi_indices[1], :
-            ] = np.nan  # add NaNs to mimic land mask
-        arr = raw_data
-
-        # adds random noise scaled by a percentage of the value
-        randomize_factor = 0.001
-        randomize_range = value * randomize_factor
-        noise = np.random.rand(*shape) * randomize_range
-        arr = arr + noise
-        return arr
-
-    sst = _arr(290.0, chunks, order, land_mask=True)
-    t_zt = _arr(280.0, chunks, order)
-    hum_zt = _arr(0.001, chunks, order)
-    u_zu = _arr(1.0, chunks, order)
-    v_zu = _arr(-1.0, chunks, order)
-    slp = _arr(101000.0, chunks, order)
-    rad_sw = _arr(0.000001, chunks, order)
-    rad_lw = _arr(350.0, chunks, order)
-    if skin_correction:
-        return sst, t_zt, hum_zt, u_zu, v_zu, rad_sw, rad_lw, slp
-    else:
-        return sst, t_zt, hum_zt, u_zu, v_zu, slp
+"""Tests for the numpy land_mask wrapper"""
 
 
 @pytest.mark.parametrize("skin_correction", [True, False])
@@ -57,7 +16,13 @@ def test_land_mask(skin_correction):
     else:
         func = noskin_np
 
-    args = create_data_np(shape, chunks=False, skin_correction=skin_correction)
+    args = create_data(
+        shape,
+        chunks=False,
+        skin_correction=skin_correction,
+        use_xr=False,
+        land_mask=True,
+    )
     out_data = func(*args, "ecmwf", 2, 10, 6)
 
     # Check the location of all NaNs is correct

--- a/tests/test_flux_np.py
+++ b/tests/test_flux_np.py
@@ -6,8 +6,20 @@ from create_test_data import create_data
 """Tests for the numpy land_mask wrapper"""
 
 
-@pytest.mark.parametrize("skin_correction", [True, False])
-def test_land_mask(skin_correction):
+@pytest.mark.parametrize(
+    "algo, skin_correction",
+    [
+        ("ecmwf", True),
+        ("ecmwf", False),
+        ("coare3p0", True),
+        ("coare3p0", False),
+        ("coare3p6", True),
+        ("coare3p6", False),
+        ("andreas", False),
+        ("ncar", False),
+    ],
+)
+def test_land_mask(skin_correction, algo):
     shape = (2, 3, 4)
     size = shape[0] * shape[1] * shape[2]
 
@@ -23,7 +35,7 @@ def test_land_mask(skin_correction):
         use_xr=False,
         land_mask=True,
     )
-    out_data = func(*args, "ecmwf", 2, 10, 6)
+    out_data = func(*args, algo, 2, 10, 6)
 
     # Check the location of all NaNs is correct
     for o in out_data:
@@ -35,6 +47,6 @@ def test_land_mask(skin_correction):
         if not np.isnan(out_data[0][index]):
             single_inputs = tuple(np.atleast_3d(i[index]) for i in args)
 
-            single_outputs = func(*single_inputs, "ecmwf", 2, 10, 6)
+            single_outputs = func(*single_inputs, algo, 2, 10, 6)
             for so, o in zip(single_outputs, out_data):
                 assert so == o[index]

--- a/tests/test_flux_np.py
+++ b/tests/test_flux_np.py
@@ -1,0 +1,75 @@
+from typing import Dict, Tuple
+
+import numpy as np
+import pytest
+from aerobulk.flux import noskin_np, skin_np
+from numpy.random import default_rng
+
+
+def create_data_np(
+    shape: Tuple[int, ...],
+    chunks: Dict[str, int] = {},
+    skin_correction: bool = False,
+    order: str = "F",
+):
+    size = shape[0] * shape[1]
+    shape2d = (shape[0], shape[1])
+    rng = default_rng()
+    indices = rng.choice(size, size=int(size * 0.3), replace=False)
+    multi_indices = np.unravel_index(indices, shape2d)
+
+    def _arr(value, chunks, order, land_mask=False):
+        raw_data = np.full(shape, value, order=order)
+        if land_mask:
+            raw_data[
+                multi_indices[0], multi_indices[1], :
+            ] = np.nan  # add NaNs to mimic land mask
+        arr = raw_data
+
+        # adds random noise scaled by a percentage of the value
+        randomize_factor = 0.001
+        randomize_range = value * randomize_factor
+        noise = np.random.rand(*shape) * randomize_range
+        arr = arr + noise
+        return arr
+
+    sst = _arr(290.0, chunks, order, land_mask=True)
+    t_zt = _arr(280.0, chunks, order)
+    hum_zt = _arr(0.001, chunks, order)
+    u_zu = _arr(1.0, chunks, order)
+    v_zu = _arr(-1.0, chunks, order)
+    slp = _arr(101000.0, chunks, order)
+    rad_sw = _arr(0.000001, chunks, order)
+    rad_lw = _arr(350.0, chunks, order)
+    if skin_correction:
+        return sst, t_zt, hum_zt, u_zu, v_zu, rad_sw, rad_lw, slp
+    else:
+        return sst, t_zt, hum_zt, u_zu, v_zu, slp
+
+
+@pytest.mark.parametrize("skin_correction", [True, False])
+def test_land_mask(skin_correction):
+    shape = (2, 3, 4)
+    size = shape[0] * shape[1] * shape[2]
+
+    if skin_correction:
+        func = skin_np
+    else:
+        func = noskin_np
+
+    args = create_data_np(shape, chunks=False, skin_correction=skin_correction)
+    out_data = func(*args, "ecmwf", 2, 10, 6)
+
+    # Check the location of all NaNs is correct
+    for o in out_data:
+        np.testing.assert_allclose(np.isnan(args[0]), np.isnan(o))
+
+    # Check that values of the unshrunk array are correct
+    for i in range(size):
+        index = np.unravel_index(i, shape)
+        if not np.isnan(out_data[0][index]):
+            single_inputs = tuple(np.atleast_3d(i[index]) for i in args)
+
+            single_outputs = func(*single_inputs, "ecmwf", 2, 10, 6)
+            for so, o in zip(single_outputs, out_data):
+                assert so == o[index]

--- a/tests/test_flux_xr.py
+++ b/tests/test_flux_xr.py
@@ -1,42 +1,9 @@
-from typing import Dict, Tuple
-
-import numpy as np
 import pytest
 import xarray as xr
 from aerobulk import noskin, skin
+from create_test_data import create_data
 
 """Tests for the xarray wrapper"""
-
-
-def create_data(
-    shape: Tuple[int, ...],
-    chunks: Dict[str, int] = {},
-    skin_correction: bool = False,
-    order: str = "F",
-):
-    def _arr(value, chunks, order):
-        arr = xr.DataArray(np.full(shape, value, order=order))
-
-        # adds random noise scaled by a percentage of the value
-        randomize_factor = 0.001
-        randomize_range = value * randomize_factor
-        arr = arr + np.random.rand(*shape) + randomize_range
-        if chunks:
-            arr = arr.chunk(chunks)
-        return arr
-
-    sst = _arr(290.0, chunks, order)
-    t_zt = _arr(280.0, chunks, order)
-    hum_zt = _arr(0.001, chunks, order)
-    u_zu = _arr(1.0, chunks, order)
-    v_zu = _arr(-1.0, chunks, order)
-    slp = _arr(101000.0, chunks, order)
-    rad_sw = _arr(0.000001, chunks, order)
-    rad_lw = _arr(350, chunks, order)
-    if skin_correction:
-        return sst, t_zt, hum_zt, u_zu, v_zu, rad_sw, rad_lw, slp
-    else:
-        return sst, t_zt, hum_zt, u_zu, v_zu, slp
 
 
 @pytest.mark.parametrize("algo", ["wrong"])

--- a/tests/test_flux_xr.py
+++ b/tests/test_flux_xr.py
@@ -66,3 +66,21 @@ class Test_xarray:
                 ii.transpose("dim_0", "dim_1", "dim_2"),
                 iii.transpose("dim_0", "dim_1", "dim_2"),
             )
+
+
+@pytest.mark.parametrize("skin_correction", [True, False])
+def test_all_input_array_sizes_valid(skin_correction):
+    shapes = (
+        (3, 4),
+        (2, 3, 4),
+        (2, 3, 4, 5),
+    )  # create_data() only allows for inputs of 2 or more dimensions
+    data = (create_data(s, skin_correction=skin_correction) for s in shapes)
+    if skin_correction:
+        func = skin
+    else:
+        func = noskin
+    tuple(func(*d, "coare3p0", 2, 10, 6) for d in data)
+    assert (
+        1 == 1
+    )  # This line is always true, but verifies that the above line doesn't crash the Fortran code


### PR DESCRIPTION
This PR does the following:
- obtains land mask info from sst field (currently assumes that the land is masked by `NaN`)
- shrinks the input arrays before sending to Fortran code
  - flattens the input arrays
  - removes land points from all variables (this should significantly help with speed up of runtime)
- unshrinks the output from the Fortran code and puts the NaNs back on land points

Additionally:
- removed the `threadsafe` for xarray, skin computations (see #39 for more discussion on ways around this)
- added the bug fix in `create_data()` from #37 
- new tests were added: `test_flux_np.py`
- separated out the creation of test data to its own file to avoid repetition: `create_test_data.py`

Closes #31  