### PR TITLE
Remove time loop and call to AEROBULK_INIT/BYE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ dist/
 source/fortran/*f2pywrappers*
 source/fortran/*.c
 source/aerobulk/aerobulk/
-mod_aerobulk_wrap.*.so
+mod_*.so
 
 # should we ignore submodules
 .DS_Store

--- a/source/aerobulk/flux.py
+++ b/source/aerobulk/flux.py
@@ -42,11 +42,7 @@ def noskin_np(
     t_zt : numpy.array
         Absolute air temperature at height zt [K]
     hum_zt : numpy.array
-        air humidity at zt, can be given as:
-            - specific humidity                   [kg/kg]
-            - dew-point temperature                   [K]
-            - relative humidity                       [%]
-            => type should normally be recognized based on value range
+        air humidity at zt, given as specific humidity [kg/kg]
     u_zu : numpy.array
         zonal wind speed at zu                    [m/s]
     v_zu : numpy.array
@@ -117,11 +113,7 @@ def skin_np(
     t_zt : numpy.array
         Absolute air temperature at height zt [K]
     hum_zt : numpy.array
-        air humidity at zt, can be given as:
-            - specific humidity                   [kg/kg]
-            - dew-point temperature                   [K]
-            - relative humidity                       [%]
-            => type should normally be recognized based on value range
+        air humidity at zt, given as specific humidity [kg/kg]
     u_zu : numpy.array
         zonal wind speed at zu                    [m/s]
     v_zu : numpy.array
@@ -190,11 +182,7 @@ def noskin(
     t_zt : xarray.DataArray
         Absolute air temperature at height zt [K]
     hum_zt : xarray.DataArray
-        air humidity at zt, can be given as:
-            - specific humidity                   [kg/kg]
-            - dew-point temperature                   [K]
-            - relative humidity                       [%]
-            => type should normally be recognized based on value range
+        air humidity at zt, given as specific humidity [kg/kg]
     u_zu : xarray.DataArray
         zonal wind speed at zu                    [m/s]
     v_zu : xarray.DataArray
@@ -290,11 +278,7 @@ def skin(
     t_zt : xr.DataArray
         Absolute air temperature at height zt [K]
     hum_zt : xr.DataArray
-        air humidity at zt, can be given as:
-            - specific humidity                   [kg/kg]
-            - dew-point temperature                   [K]
-            - relative humidity                       [%]
-            => type should normally be recognized based on value range
+        air humidity at zt, given as specific humidity [kg/kg]
     u_zu : xr.DataArray
         zonal wind speed at zu                    [m/s]
     v_zu : xr.DataArray

--- a/source/fortran/mod_aerobulk_wrap_noskin.f90
+++ b/source/fortran/mod_aerobulk_wrap_noskin.f90
@@ -25,17 +25,15 @@ CONTAINS
     INTEGER,                  INTENT(in) :: Niter
     REAL(8), DIMENSION(Ni,Nj,Nt), INTENT(out) :: QL, QH, Tau_x, Tau_y, Evap
 
-    INTEGER n
-
     nb_iter = Niter
     !! All the variables that are set in INIT
     ctype_humidity = 'sh'
     l_use_skin_schemes = .FALSE.
 
-    CALL AEROBULK_COMPUTE(n, calgo, zt, zu, sst(:, :, n), t_zt(:, :, n), &
-      &                  hum_zt(:, :, n), U_zu(:, :, n), V_zu(:, :, n), slp(:, :, n),  &
-      &                  QL(:, :, n), QH(:, :, n), Tau_x(:, :, n), Tau_y(:, :, n),     &
-      &                  Evp=Evap(:, :, n))
+    CALL AEROBULK_COMPUTE(1, calgo, zt, zu, sst(:, :, 1), t_zt(:, :, 1), &
+      &                  hum_zt(:, :, 1), U_zu(:, :, 1), V_zu(:, :, 1), slp(:, :, 1),  &
+      &                  QL(:, :, 1), QH(:, :, 1), Tau_x(:, :, 1), Tau_y(:, :, 1),     &
+      &                  Evp=Evap(:, :, 1))
 
     CALL AEROBULK_BYE()
 

--- a/source/fortran/mod_aerobulk_wrap_noskin.f90
+++ b/source/fortran/mod_aerobulk_wrap_noskin.f90
@@ -28,12 +28,9 @@ CONTAINS
     INTEGER n
 
     nb_iter = Niter
-
-    !! initialize based on first timestep
-    CALL AEROBULK_INIT(Nt, calgo, sst(:, :, 1), t_zt(:, :, 1), &
-        &              hum_zt(:, :, 1), U_zu(:, :, 1), V_zu(:, :, 1), slp(:, :, 1), &
-        &              l_use_skin=.FALSE. )
-
+    !! All the variables that are set in INIT
+    ctype_humidity = 'sh'
+    l_use_skin_schemes = .FALSE.
     DO n = 1, Nt
        CALL AEROBULK_COMPUTE(n, calgo, zt, zu, sst(:, :, n), t_zt(:, :, n), &
           &                  hum_zt(:, :, n), U_zu(:, :, n), V_zu(:, :, n), slp(:, :, n),  &

--- a/source/fortran/mod_aerobulk_wrap_noskin.f90
+++ b/source/fortran/mod_aerobulk_wrap_noskin.f90
@@ -31,12 +31,11 @@ CONTAINS
     !! All the variables that are set in INIT
     ctype_humidity = 'sh'
     l_use_skin_schemes = .FALSE.
-    DO n = 1, Nt
-       CALL AEROBULK_COMPUTE(n, calgo, zt, zu, sst(:, :, n), t_zt(:, :, n), &
-          &                  hum_zt(:, :, n), U_zu(:, :, n), V_zu(:, :, n), slp(:, :, n),  &
-          &                  QL(:, :, n), QH(:, :, n), Tau_x(:, :, n), Tau_y(:, :, n),     &
-          &                  Evp=Evap(:, :, n))
-    END DO
+
+    CALL AEROBULK_COMPUTE(n, calgo, zt, zu, sst(:, :, n), t_zt(:, :, n), &
+      &                  hum_zt(:, :, n), U_zu(:, :, n), V_zu(:, :, n), slp(:, :, n),  &
+      &                  QL(:, :, n), QH(:, :, n), Tau_x(:, :, n), Tau_y(:, :, n),     &
+      &                  Evp=Evap(:, :, n))
 
     CALL AEROBULK_BYE()
 

--- a/source/fortran/mod_aerobulk_wrap_skin.f90
+++ b/source/fortran/mod_aerobulk_wrap_skin.f90
@@ -26,18 +26,17 @@ CONTAINS
     REAL(8), DIMENSION(Ni,Nj,Nt), INTENT(out) :: QL, QH, Tau_x, Tau_y, T_s, Evap
 
     INTEGER n
+
     nb_iter = Niter
     !! All the variables that are set in INIT
     ctype_humidity = 'sh'
     l_use_skin_schemes = .TRUE.
-    DO n = 1, Nt
-       CALL AEROBULK_COMPUTE(n, calgo, zt, zu, sst(:, :, n), t_zt(:, :, n), &
-          &                  hum_zt(:, :, n), U_zu(:, :, n), V_zu(:, :, n), slp(:, :, n),  &
-          &                  QL(:, :, n), QH(:, :, n), Tau_x(:, :, n), Tau_y(:, :, n),     &
-          &                  rad_sw=rad_sw(:, :, n), rad_lw=rad_lw(:, :, n), T_s=T_s(:, :, n), Evp=Evap(:, :, n))
-    END DO
 
-    CALL AEROBULK_BYE()
+    n=1 ! This will always be 1 since we shrink arrays to 1d
+    CALL AEROBULK_COMPUTE(1, calgo, zt, zu, sst(:, :, n), t_zt(:, :, n), &
+      &                  hum_zt(:, :, n), U_zu(:, :, n), V_zu(:, :, n), slp(:, :, n),  &
+      &                  QL(:, :, n), QH(:, :, n), Tau_x(:, :, n), Tau_y(:, :, n),     &
+      &                  rad_sw=rad_sw(:, :, n), rad_lw=rad_lw(:, :, n), T_s=T_s(:, :, n), Evp=Evap(:, :, n))
 
   END SUBROUTINE AEROBULK_MODEL_SKIN
 

--- a/source/fortran/mod_aerobulk_wrap_skin.f90
+++ b/source/fortran/mod_aerobulk_wrap_skin.f90
@@ -25,18 +25,15 @@ CONTAINS
     INTEGER,                  INTENT(in) :: Niter
     REAL(8), DIMENSION(Ni,Nj,Nt), INTENT(out) :: QL, QH, Tau_x, Tau_y, T_s, Evap
 
-    INTEGER n
-
     nb_iter = Niter
     !! All the variables that are set in INIT
     ctype_humidity = 'sh'
     l_use_skin_schemes = .TRUE.
 
-    n=1 ! This will always be 1 since we shrink arrays to 1d
-    CALL AEROBULK_COMPUTE(1, calgo, zt, zu, sst(:, :, n), t_zt(:, :, n), &
-      &                  hum_zt(:, :, n), U_zu(:, :, n), V_zu(:, :, n), slp(:, :, n),  &
-      &                  QL(:, :, n), QH(:, :, n), Tau_x(:, :, n), Tau_y(:, :, n),     &
-      &                  rad_sw=rad_sw(:, :, n), rad_lw=rad_lw(:, :, n), T_s=T_s(:, :, n), Evp=Evap(:, :, n))
+    CALL AEROBULK_COMPUTE(1, calgo, zt, zu, sst(:, :, 1), t_zt(:, :, 1), &
+      &                  hum_zt(:, :, 1), U_zu(:, :, 1), V_zu(:, :, 1), slp(:, :, 1),  &
+      &                  QL(:, :, 1), QH(:, :, 1), Tau_x(:, :, 1), Tau_y(:, :, 1),     &
+      &                  rad_sw=rad_sw(:, :, 1), rad_lw=rad_lw(:, :, 1), T_s=T_s(:, :, 1), Evp=Evap(:, :, 1))
 
   END SUBROUTINE AEROBULK_MODEL_SKIN
 

--- a/source/fortran/mod_aerobulk_wrap_skin.f90
+++ b/source/fortran/mod_aerobulk_wrap_skin.f90
@@ -26,14 +26,10 @@ CONTAINS
     REAL(8), DIMENSION(Ni,Nj,Nt), INTENT(out) :: QL, QH, Tau_x, Tau_y, T_s, Evap
 
     INTEGER n
-
     nb_iter = Niter
-
-    !! initialize based on first timestep
-    CALL AEROBULK_INIT(Nt, calgo, sst(:, :, 1), t_zt(:, :, 1), &
-        &              hum_zt(:, :, 1), U_zu(:, :, 1), V_zu(:, :, 1), slp(:, :, 1), &
-        &              l_use_skin=.TRUE., prsw=rad_sw(:, :, 1), prlw=rad_lw(:, :, 1))
-
+    !! All the variables that are set in INIT
+    ctype_humidity = 'sh'
+    l_use_skin_schemes = .FALSE.
     DO n = 1, Nt
        CALL AEROBULK_COMPUTE(n, calgo, zt, zu, sst(:, :, n), t_zt(:, :, n), &
           &                  hum_zt(:, :, n), U_zu(:, :, n), V_zu(:, :, n), slp(:, :, n),  &

--- a/source/fortran/mod_aerobulk_wrap_skin.f90
+++ b/source/fortran/mod_aerobulk_wrap_skin.f90
@@ -29,7 +29,7 @@ CONTAINS
     nb_iter = Niter
     !! All the variables that are set in INIT
     ctype_humidity = 'sh'
-    l_use_skin_schemes = .FALSE.
+    l_use_skin_schemes = .TRUE.
     DO n = 1, Nt
        CALL AEROBULK_COMPUTE(n, calgo, zt, zu, sst(:, :, n), t_zt(:, :, n), &
           &                  hum_zt(:, :, n), U_zu(:, :, n), V_zu(:, :, n), slp(:, :, n),  &

--- a/tests/test_flux_xr.py
+++ b/tests/test_flux_xr.py
@@ -20,7 +20,8 @@ def create_data(
         # adds random noise scaled by a percentage of the value
         randomize_factor = 0.001
         randomize_range = value * randomize_factor
-        arr = arr + np.random.rand(*shape) + randomize_range
+        noise = np.random.rand(*shape) * randomize_range
+        arr = arr + noise
         if chunks:
             arr = arr.chunk(chunks)
         return arr
@@ -58,7 +59,7 @@ def test_algo_error_skin(algo):
 @pytest.mark.parametrize(
     "chunks", [{"dim_2": -1}, {"dim_0": 10}, {"dim_0": 1}, {"dim_2": 8}, {"dim_2": 1}]
 )
-@pytest.mark.parametrize("skin_correction", [True, False])
+@pytest.mark.parametrize("skin_correction", [False, True])
 class Test_xarray:
     def test_chunked(self, chunks, skin_correction):
         shape = (10, 13, 12)


### PR DESCRIPTION
- Closes #36 #24

This strips more of the aerobulk complexity out of our fortran wrappers. We can drop the loop entirely since thanks to #40 
 internally we will only ever deal with 1D arrays that do not extend in the third dimension (they only have a singelton dimensions due to the restrictions aerobulk applies).

This also removes the 'auto-detection' of humidity units and strictly requires specific humidity as input.