### PR TITLE
Introduce a value range check on the numpy level

### DIFF
--- a/source/aerobulk/flux.py
+++ b/source/aerobulk/flux.py
@@ -33,12 +33,6 @@ def _check_value_range(*args):
             ["sst", "t_zt", "hum_zt", "u_zu", "v_zu", "slp", "rad_sw", "rad_lw"], args
         )
     }
-    performance_msg = (
-        "Checking for misaligned nans and values outside of the valid range is performed by default, but reduces performance. \n"
-        "If you are sure your data is valid you can deactivate these checks by setting `input_range_check=False`"
-    )
-    warnings.warn(performance_msg)
-
     for var, data in args_dict.items():
         # check for misaligned nans
         if var != "sst":
@@ -278,6 +272,12 @@ def noskin(
     sst, t_zt, hum_zt, u_zu, v_zu, slp = xr.broadcast(
         sst, t_zt, hum_zt, u_zu, v_zu, slp
     )
+    if input_range_check:
+        performance_msg = (
+            "Checking for misaligned nans and values outside of the valid range is performed by default, but reduces performance. \n"
+            "If you are sure your data is valid you can deactivate these checks by setting `input_range_check=False`"
+        )
+        warnings.warn(performance_msg)
 
     out_vars = xr.apply_ufunc(
         noskin_np,
@@ -382,6 +382,13 @@ def skin(
     sst, t_zt, hum_zt, u_zu, v_zu, rad_sw, rad_lw, slp = xr.broadcast(
         sst, t_zt, hum_zt, u_zu, v_zu, rad_sw, rad_lw, slp
     )
+
+    if input_range_check:
+        performance_msg = (
+            "Checking for misaligned nans and values outside of the valid range is performed by default, but reduces performance. \n"
+            "If you are sure your data is valid you can deactivate these checks by setting `input_range_check=False`"
+        )
+        warnings.warn(performance_msg)
 
     out_vars = xr.apply_ufunc(
         skin_np,

--- a/source/aerobulk/flux.py
+++ b/source/aerobulk/flux.py
@@ -48,7 +48,7 @@ def _check_value_range(*args):
         out_of_range = ~np.logical_and(data >= range[0], data <= range[1])
         if out_of_range.any():
             raise ValueError(
-                f"Found values in {var} that are out of the valid range ({-range[0] if range[2] else range[0]}-{range[1]})."
+                f"Found values in {var} that are out of the valid range ({range[0]}-{range[1]})."
             )
 
 

--- a/source/aerobulk/flux.py
+++ b/source/aerobulk/flux.py
@@ -38,7 +38,7 @@ def _check_value_range(*args):
         if var != "sst":
             if np.isnan(data).any():
                 raise ValueError(
-                    f"Found nans in {var} that do not align with nans in `sst`.\nCheck that nans in all fields are matched."
+                    f"Found nans in {var} that do not align with nans in `sst`. Check that nans in all fields are matched."
                 )
 
         # check for valid range

--- a/source/aerobulk/flux.py
+++ b/source/aerobulk/flux.py
@@ -5,11 +5,54 @@ import xarray as xr
 
 VALID_ALGOS = ["coare3p0", "coare3p6", "ecmwf", "ncar", "andreas"]
 VALID_ALGOS_SKIN = ["coare3p0", "coare3p6", "ecmwf"]
+VALID_VALUE_RANGES = {
+    "sst": [270, 320, False],
+    "t_zt": [180, 330, False],
+    "hum_zt": [0, 0.08, False],
+    "u_zu": [0, 50, True],
+    "v_zu": [0, 50, True],
+    "slp": [80000, 110000, False],
+    "rad_sw": [0, 1500, False],
+    "rad_lw": [0, 750, False],
+}
 
 
 def _check_algo(algo, valids):
     if algo not in valids:
         raise ValueError(f"Algorithm {algo} not valid. Choose from {valids}.")
+
+
+def _check_value_range(*args):
+    """Checks the input ranges for input fields"""
+    # parse inputs to names
+    args_dict = {
+        k: v
+        for k, v in zip(
+            ["sst", "t_zt", "hum_zt", "u_zu", "v_zu", "slp", "rad_sw", "rad_lw"], args
+        )
+    }
+
+    for var, data in args_dict.items():
+        # check for misaligned nans
+        if var != "sst":
+            if np.isnan(data).any():
+                raise ValueError(
+                    f"Found nans in {var} that do not align with nans in `sst`. Check that nans in all fields are matched."
+                )
+
+        # check for valid range
+        range = VALID_VALUE_RANGES[var]
+        range_data = data
+        # check the absolute value if specified in range
+        if range[2]:
+            range_data = abs(range_data)
+
+        # check that values are in range
+        out_of_range = ~np.logical_and(range_data >= range[0], range_data <= range[1])
+        if out_of_range.any():
+            raise ValueError(
+                f"Found values in {var} that are out of the valid range ({-range[0] if range[2] else range[0]}-{range[1]})."
+            )
 
 
 # Unshrink the data (i.e. put land NaN values back in their correct locations)
@@ -20,16 +63,7 @@ def unshrink_arr(shrunk_array, shape, ocean_index):
 
 
 def noskin_np(
-    sst,
-    t_zt,
-    hum_zt,
-    u_zu,
-    v_zu,
-    slp,
-    algo,
-    zt,
-    zu,
-    niter,
+    sst, t_zt, hum_zt, u_zu, v_zu, slp, algo, zt, zu, niter, input_range_check
 ):
     """Python wrapper for aerobulk without skin correction.
     !ATTENTION If input not provided in correct units, will crash.
@@ -81,6 +115,9 @@ def noskin_np(
         np.atleast_3d(a[ocean_index]) for a in (sst, t_zt, hum_zt, u_zu, v_zu, slp)
     )
 
+    if input_range_check:
+        _check_value_range(*args_shrunk)
+
     out_data = aeronoskin.mod_aerobulk_wrapper_noskin.aerobulk_model_noskin(
         algo, zt, zu, *args_shrunk, niter
     )
@@ -94,13 +131,14 @@ def skin_np(
     hum_zt,
     u_zu,
     v_zu,
+    slp,
     rad_sw,
     rad_lw,
-    slp,
     algo,
     zt,
     zu,
     niter,
+    input_range_check,
 ):
     """Python wrapper for aerobulk with skin correction.
     !ATTENTION If input not provided in correct units, will crash.
@@ -158,6 +196,9 @@ def skin_np(
         for a in (sst, t_zt, hum_zt, u_zu, v_zu, slp, rad_sw, rad_lw)
     )
 
+    if input_range_check:
+        _check_value_range(*args_shrunk)
+
     out_data = aeroskin.mod_aerobulk_wrapper_skin.aerobulk_model_skin(
         algo, zt, zu, *args_shrunk, niter
     )
@@ -166,7 +207,17 @@ def skin_np(
 
 
 def noskin(
-    sst, t_zt, hum_zt, u_zu, v_zu, slp=101000.0, algo="coare3p0", zt=2, zu=10, niter=6
+    sst,
+    t_zt,
+    hum_zt,
+    u_zu,
+    v_zu,
+    slp=101000.0,
+    algo="coare3p0",
+    zt=2,
+    zu=10,
+    niter=6,
+    input_range_check=True,
 ):
     """xarray wrapper for aerobulk without skin correction.
 
@@ -202,6 +253,9 @@ def noskin(
     niter : int, optional
         Number of iteration steps used in the algorithm,
         by default 6
+    input_range_check: bool, optional
+        Turn on/off explicit checking of input variables for valid ranges.
+        On by default, but for best performance should be turned off
 
     Returns
     -------
@@ -234,10 +288,7 @@ def noskin(
         output_core_dims=[()] * 5,
         dask="parallelized",
         kwargs=dict(
-            algo=algo,
-            zt=zt,
-            zu=zu,
-            niter=niter,
+            algo=algo, zt=zt, zu=zu, niter=niter, input_range_check=input_range_check
         ),
         output_dtypes=[sst.dtype]
         * 5,  # deactivates the 1 element check which aerobulk does not like
@@ -262,6 +313,7 @@ def skin(
     zt=2,
     zu=10,
     niter=6,
+    input_range_check=True,
 ):
 
     """xarray wrapper for aerobulk with skin correction.
@@ -302,6 +354,9 @@ def skin(
     niter : int, optional
         Number of iteration steps used in the algorithm,
         by default 6
+    input_range_check: bool, optional
+        Turn on/off explicit checking of input variables for valid ranges.
+        On by default, but for best performance should be turned off
 
     Returns
     -------
@@ -339,10 +394,7 @@ def skin(
         output_core_dims=[()] * 6,
         dask="parallelized",
         kwargs=dict(
-            algo=algo,
-            zt=zt,
-            zu=zu,
-            niter=niter,
+            algo=algo, zt=zt, zu=zu, niter=niter, input_range_check=input_range_check
         ),
         output_dtypes=[sst.dtype]
         * 6,  # deactivates the 1 element check which aerobulk does not like

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -12,6 +12,14 @@ def create_data(
     order: str = "F",
     use_xr=True,
     land_mask=False,
+    sst=290.0,
+    t_zt=280.0,
+    hum_zt=0.001,
+    u_zu=1.0,
+    v_zu=-1.0,
+    slp=101000.0,
+    rad_sw=0.000001,
+    rad_lw=350.0,
 ):
     size = shape[0] * shape[1]
     shape2d = (shape[0], shape[1])
@@ -37,15 +45,21 @@ def create_data(
                 arr = arr.chunk(chunks)
         return arr
 
-    sst = _arr(290.0, chunks, order)
-    t_zt = _arr(280.0, chunks, order)
-    hum_zt = _arr(0.001, chunks, order)
-    u_zu = _arr(1.0, chunks, order)
-    v_zu = _arr(-1.0, chunks, order)
-    slp = _arr(101000.0, chunks, order)
-    rad_sw = _arr(0.000001, chunks, order)
-    rad_lw = _arr(350.0, chunks, order)
     if skin_correction:
-        return sst, t_zt, hum_zt, u_zu, v_zu, rad_sw, rad_lw, slp
+        return tuple(
+            _arr(a, chunks, order)
+            for a in (
+                sst,
+                t_zt,
+                hum_zt,
+                u_zu,
+                v_zu,
+                slp,
+                rad_sw,
+                rad_lw,
+            )
+        )
     else:
-        return sst, t_zt, hum_zt, u_zu, v_zu, slp
+        return tuple(
+            _arr(a, chunks, order) for a in (sst, t_zt, hum_zt, u_zu, v_zu, slp)
+        )

--- a/tests/test_fortran.py
+++ b/tests/test_fortran.py
@@ -40,7 +40,17 @@ def test_fortran_noskin(algo, expected):
     v_zu = np.atleast_3d(0)
     slp = np.atleast_3d(101000.0)  # Pa
     ql, qh, taux, tauy, evap = noskin_np(
-        sst, t_zt, hum_zt, u_zu, v_zu, slp, algo=algo, zt=2, zu=10, niter=10
+        sst,
+        t_zt,
+        hum_zt,
+        u_zu,
+        v_zu,
+        slp,
+        algo=algo,
+        zt=2,
+        zu=10,
+        niter=10,
+        input_range_check=True,
     )
     evap = evap * 3600 * 24  # convert to mm/day
 
@@ -108,13 +118,14 @@ def test_fortran_skin(algo, expected):
         hum_zt,
         u_zu,
         v_zu,
+        slp,
         rad_sw,
         rad_lw,
-        slp,
         algo=algo,
         zt=2,
         zu=10,
         niter=10,
+        input_range_check=True,
     )
     evap = evap * 3600 * 24  # convert to mm/day
     t_s = t_s - rt0


### PR DESCRIPTION
- [x] Closes #29, #4, #11

I have implemented a checking function on the numpy level that can be turned on/off. This function checks the 'shrunken' arguments for nans and values that are out of the allowed range. This should completely eliminate the need for propagating errors from the fortran level (#4, #11), since we are now catching eveything that would lead to a `STOP` in fortran at the python level.  