### PR TITLE
Provisional fix for wind stress limit error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "source/fortran/aerobulk"]
 	path = source/fortran/aerobulk
-	url = git@github.com:brodeau/aerobulk.git
+	url = git@github.com:jbusecke/aerobulk.git
+	branch = patch-2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "source/fortran/aerobulk"]
 	path = source/fortran/aerobulk
 	url = git@github.com:jbusecke/aerobulk.git
-	branch = patch-2


### PR DESCRIPTION
Currently aerobulk has limit of 5N/m^2 [hardcoded](https://github.com/brodeau/aerobulk/blob/5cf0f8b0156d165279d701e963752d0ca50b57b7/src/mod_const.f90#L149). As discussed [here](https://github.com/brodeau/aerobulk/issues/15) we can probably update that value to at least 10N/m^2.

I have submitted a PR [upstream](https://github.com/brodeau/aerobulk/pull/16) to increase the limit. 

This PR is swapping the submodule pointer from the upstream main repo to my personal PR branch to implement this fix in our code base ASAP. As soon as this is fixed upstream, we should repoint to the official aerobulk repo.