### PR TITLE
Include range endpoints in input_range_check

### DIFF
--- a/source/aerobulk/flux.py
+++ b/source/aerobulk/flux.py
@@ -45,7 +45,7 @@ def _check_value_range(*args):
         range = VALID_VALUE_RANGES[var]
 
         # check that values are in range
-        out_of_range = ~np.logical_and(data >= range[0], data <= range[1])
+        out_of_range = ~np.logical_and(data > range[0], data < range[1])
         if out_of_range.any():
             raise ValueError(
                 f"Found values in {var} that are out of the valid range ({range[0]}-{range[1]})."


### PR DESCRIPTION
While running `aeroubulk-python` today I ran into an error from the `input_range_check` that the shortwave radiation had values not within range. Investigating further it became clear that there are many points that are exactly equal to zero, which is the bottom end of the acceptable range for that variable.

This PR updates the code so that both the endpoints of the range are included as acceptable. I.e. whereas we previously had `(range_start,range_end)` we now have `[range_start,range_end]`, where the square brackets include the end points.