### PR TITLE
Do not use python 3.12 for publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Related to #75 I noticed that our [recent release](https://github.com/xgcm/aerobulk-python/actions/runs/8008831531/job/21876131327) failed. That action was using python 3.12, and this PR should hopefully fix that particular issue. 